### PR TITLE
Add support for creating an RPM package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,6 @@
 cmake_minimum_required(VERSION 3.0.2)
 project(eovim LANGUAGES C VERSION 0.1.2.99)
 
-include(CPack)
 include(CheckTypeSize)
 
 # Try to determine the architecture (32/64 bits) we are compiling for.  This
@@ -47,6 +46,25 @@ configure_file(
    "${CMAKE_SOURCE_DIR}/cmake/Modules/version.h.in"
    "${BUILD_INCLUDE_DIR}/eovim/version.h"
    @ONLY)
+
+execute_process(COMMAND git tag -l WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} OUTPUT_VARIABLE VERSION_STRING OUTPUT_STRIP_TRAILING_WHITESPACE)
+string(REGEX MATCHALL "[0-9.]+" VERSION_LIST "${VERSION_STRING}")
+list(GET VERSION_LIST -1 VERSION)
+set(CPACK_RPM_PACKAGE_RELOCATABLE TRUE)
+set(CPACK_PACKAGE_VERSION "${VERSION}")
+set(CPACK_GENERATOR "RPM")
+set(CPACK_PACKAGE_NAME "eovim")
+set(CPACK_PACKAGE_RELEASE 1)
+set(CPACK_PACKAGE_DESCRIPTION_SUMMARY "Eovim is the Enlightened Neovim")
+set(CPACK_PACKAGE_VENDOR "Jean Guyomarc'h")
+set(CPACK_PACKAGING_INSTALL_PREFIX ${CMAKE_INSTALL_PREFIX})
+set(CPACK_PACKAGE_FILE_NAME "${CPACK_PACKAGE_NAME}-${CPACK_PACKAGE_VERSION}-${CPACK_PACKAGE_RELEASE}.${CMAKE_SYSTEM_PROCESSOR}")
+set(CPACK_RPM_PACKAGE_LICENSE "MIT")
+set(CPACK_RPM_PACKAGE_GROUP "Applications/Editors")
+set(CPACK_RPM_PACKAGE_DESCRIPTION "Eovim is the Enlightened Neovim. That's just an EFL GUI client for Neovim.")
+set(CPACK_RPM_PACKAGE_REQUIRES "neovim >= 0.2.0, efl >= 1.20")
+
+include(CPack)
 
 find_package(Eina REQUIRED)
 find_package(Eet REQUIRED)


### PR DESCRIPTION
As requested in #3 and being a Fedora user myself, I read up how to do exactly that and here's the commit for it. Just do a `make package` in the build directory after you ran `cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_INSTALL_PREFIX=/usr ..` and you'll get a nice RPM.